### PR TITLE
[TASK] Properly log exceptions

### DIFF
--- a/Classes/Yeebase/Graylog/GraylogService.php
+++ b/Classes/Yeebase/Graylog/GraylogService.php
@@ -97,7 +97,7 @@ class GraylogService {
 
 		// build message context
 		$messageContext = array(
-			'full_message' => $exception->getTraceAsString(),
+			'exception' => $exception,
 			'reference_code' => $exception instanceof FlowException ? $exception->getReferenceCode() : NULL,
 			'response_status' => $statusCode,
 			'short_message' => sprintf('%d %s', $statusCode, Response::getStatusMessageByCode($statusCode)),


### PR DESCRIPTION
This patch adjusts the `GraylogService` to log
exceptions recursively (including previous exceptions)
as demonstrated in the official library:
https://github.com/bzikarsky/gelf-php/blob/master/examples/exception-logging.php

Resolves: TECH-782
