### PR TITLE
FEATURE: Log all messages to System Logger as well

### DIFF
--- a/Classes/Log/Backend/GraylogBackend.php
+++ b/Classes/Log/Backend/GraylogBackend.php
@@ -8,6 +8,7 @@ namespace Yeebase\Graylog\Log\Backend;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\Backend\AbstractBackend;
+use Neos\Flow\Log\SystemLoggerInterface;
 use Yeebase\Graylog\GraylogService;
 
 /**
@@ -23,10 +24,21 @@ class GraylogBackend extends AbstractBackend
     protected $graylogService;
 
     /**
+     * @Flow\Inject
+     * @var SystemLoggerInterface
+     */
+    protected $systemLogger;
+
+    /**
      * An array of severity labels, indexed by their integer constant
      * @var array
      */
     protected $severityLabels;
+
+    /**
+     * @var bool
+     */
+    protected $alsoLogWithSystemLogger;
 
     /**
      * This method will send a message to our graylog service
@@ -58,6 +70,10 @@ class GraylogBackend extends AbstractBackend
         !is_null($severityLabel) ? $messageContext['severityLabel'] = $severityLabel : '';
 
         $this->graylogService->logMessage($output, $messageContext, $severity);
+
+        if ($this->alsoLogWithSystemLogger) {
+            $this->systemLogger->log($output, $severity, $additionalData, $packageKey, $className, $methodName);
+        }
     }
 
     public function open()
@@ -76,5 +92,13 @@ class GraylogBackend extends AbstractBackend
 
     public function close()
     {
+    }
+
+    /**
+     * @param bool $alsoLogWithSystemLogger
+     */
+    public function setAlsoLogWithSystemLogger(bool $alsoLogWithSystemLogger)
+    {
+        $this->alsoLogWithSystemLogger = $alsoLogWithSystemLogger;
     }
 }

--- a/Configuration/Development/Settings.yaml
+++ b/Configuration/Development/Settings.yaml
@@ -1,0 +1,5 @@
+Yeebase:
+  Graylog:
+    Logger:
+      backendOptions:
+        alsoLogWithSystemLogger: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,7 +11,8 @@ Yeebase:
       backend: Yeebase\Graylog\Log\Backend\GraylogBackend
       backendOptions:
         severityThreshold: '%LOG_INFO%'
-        logIpAddress: TRUE
+        logIpAddress: true
+        alsoLogWithSystemLogger: false
 
 ## Optional: Register GraylogExceptionHandler
 #Neos:

--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ class SomeClass
 }
 
 ```
+
+By default messages will also be logged to the `SystemLoggerInterface` when Flow runs in `Development` context. You
+can enable or disable this function with a setting:
+
+```yaml
+Yeebase:
+  Graylog:
+    Logger:
+      backendOptions:
+        alsoLogWithSystemLogger: true
+```


### PR DESCRIPTION
This change introduces a setting which lets the Graylog backend additionally log messages to the standard System Logger. That function can be quite handy while developing an application and is therefore enabled by default for the Development context.